### PR TITLE
Use version-sensitive compare in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ find_package(Qt5Test REQUIRED)
 # Test for supported Qt version
 find_program(QMAKE_EXECUTABLE NAMES qmake HINTS ${QTDIR} ENV QTDIR PATH_SUFFIXES bin)
 execute_process(COMMAND ${QMAKE_EXECUTABLE} -query QT_VERSION OUTPUT_VARIABLE QT_VERSION)
-if(QT_VERSION LESS QT_MINIMUM_VERSION)
+if(QT_VERSION VERSION_LESS QT_MINIMUM_VERSION)
 	MESSAGE(FATAL_ERROR "Minimum supported Qt version: ${QT_MINIMUM_VERSION}. Installed version: ${QT_VERSION}")
 endif()
 


### PR DESCRIPTION
The current version of Qt is 5.10.1, which despite being a higher version than the prerequisite `QT_MINIMUM_VERSION` of 5.3.0, is tripping the `QT_VERSION LESS QT_MINIMUM_VERSION` test.  (I believe the behavior of the `LESS` operator is to convert as much of the two values to numeric as possible, so in this case: "5.10.1" --> 5.1, "5.3.0" --> 5.3, and then compare, such that 5.1 < 5.3)

To fix this, CMake has a specific comparison operator [`VERSION_LESS`](https://cmake.org/cmake/help/latest/command/if.html) that considers version strings as dot-separated values like `major[.minor[.patch[.tweak]]]`.

From a (really) quick Windows-only test build, using 5.10.1 seems to compile and run fine.... please let me know what other testing you might like me to attempt on this change :)