### PR TITLE
Added Ctrl-F5 to "Run All Tests" and set working directory

### DIFF
--- a/src/mainwindow_p.h
+++ b/src/mainwindow_p.h
@@ -155,6 +155,7 @@ public:
 	QAction*								selectAndKillTest;						///< Selects and kills a running test.
 	QAction*								selectAndRemoveTestAction;				///< Remove a test after choosing it from a list.
 	QAction*								selectAndRunTest;						///< Run a test after selecting it from a list.																	///< program options.
+	QAction*								selectAndRunAllTest;					///< Run all tests in the list.
 
 	QMenu*									testCaseViewContextMenu;				///< Context menu for the test case tree view
 	QAction*								testCaseViewExpandAllAction;			///< expands all nodes in the test case tree view


### PR DESCRIPTION
Added Ctrl-F5 to "Run All Tests" (we got lots of unit test executables and sometimes I just want to force-run them all in one command)

Also, some of our tests need to read in data files and these are usually relative to the test executable. 
(I believe, this is a very common assumption)